### PR TITLE
Update style of dishes index; recipe and restaurant seeds

### DIFF
--- a/app/assets/stylesheets/components/_map.scss
+++ b/app/assets/stylesheets/components/_map.scss
@@ -14,6 +14,7 @@
   margin: 0;
   padding: 10px;
   border-radius: 3px 3px 0 0;
+  font-size: small;
   font-weight: 600;
   letter-spacing: 1px;
   line-height: 20px;
@@ -23,7 +24,7 @@
   margin: 0;
   padding: 10px;
   font-weight: 400;
-  opacity: .7;
+  font-size: x-small;
 }
 
 .mapboxgl-popup-content div {

--- a/app/assets/stylesheets/components/_map.scss
+++ b/app/assets/stylesheets/components/_map.scss
@@ -3,5 +3,8 @@
 }
 
 .mapboxgl-popup-content {
+  justify-content: center;
   text-align: center;
+  padding: 15px 10px 0px;
+  align-items: center;
 }

--- a/app/assets/stylesheets/components/_map.scss
+++ b/app/assets/stylesheets/components/_map.scss
@@ -1,10 +1,54 @@
-.mapboxgl-popup {
-  max-width: 200px;
+.mapboxgl-popup-close-button {
+  display: none;
 }
 
 .mapboxgl-popup-content {
+  font: 400 15px/22px 'Source Sans Pro', 'Helvetica Neue', sans-serif;
+  padding: 0;
+  width: 180px;
+}
+
+.mapboxgl-popup-content h6 {
+  background: $accent-g;
+  color: #fff;
+  margin: 0;
+  padding: 10px;
+  border-radius: 3px 3px 0 0;
+  font-weight: 600;
+  letter-spacing: 1px;
+  line-height: 20px;
+}
+
+.mapboxgl-popup-content p {
+  margin: 0;
+  padding: 10px;
+  font-weight: 400;
+  opacity: .7;
+}
+
+.mapboxgl-popup-content div {
+  padding: 0px;
   justify-content: center;
   text-align: center;
-  padding: 15px 10px 0px;
   align-items: center;
 }
+
+.mapboxgl-popup-anchor-top > .mapboxgl-popup-content {
+  margin-top: 15px;
+}
+
+// .mapboxgl-popup-anchor-top > .mapboxgl-popup-tip {
+  //   border-bottom-color: #91c949;
+  // }
+
+  // .mapboxgl-popup {
+  //   max-width: 200px;
+  // }
+
+  // .mapboxgl-popup-content {
+  //   border: 0px;
+  //   justify-content: center;
+  //   text-align: center;
+  //   align-items: center;
+    // padding: 15px 10px 0px;
+  // }

--- a/app/assets/stylesheets/pages/_dishes_index.scss
+++ b/app/assets/stylesheets/pages/_dishes_index.scss
@@ -94,7 +94,7 @@ a:hover {
   justify-content: space-around;
   font-size: 22px;
   color: white;
-  padding: 10px;
+  padding: 20px 10px;
   letter-spacing: 1px;
   font-weight: 500;
   text-shadow: 0 0 10px rgba(0,0,0,0.7);

--- a/app/assets/stylesheets/pages/_dishes_index.scss
+++ b/app/assets/stylesheets/pages/_dishes_index.scss
@@ -50,12 +50,12 @@
 // Container for a dish - default block
 .dish-card {
   overflow: hidden;
-  background: white;
   box-shadow: 0 0 6px rgba(0,0,0,0.25);
 }
 
 .dish-card:hover {
-  background: $base-bkg-green;
+  background: $accent-g;
+  transition: all .1s ease-in-out 2s;
 }
 
 .dish-card h2 {
@@ -97,20 +97,46 @@ a:hover {
   padding: 30px 10px;
   letter-spacing: 1px;
   font-weight: 500;
-  text-shadow: 0 0 10px rgba(0,0,0,0.7);
+  text-shadow: 0 0 15px rgba(0,0,0,0.7);
 }
 
+// .dish-card:hover .dish-hero {
+//   transition: all .1s ease-in 6s;
+//   background: green;
+// }
 
 // Container for dish info - flex
 .dish-card .dish-infos {
-  padding: 16px;
+  background: white;
+  padding: 16px 16px 0px;
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
   position: relative;
 }
 
+.dish-card:hover .dish-infos {
+  background: $base-bkg-green;
+}
+
 .dish-card .restaurant-info {
+  padding: 16px;
+  background: white;
+  display: flex;
+  // justify-content: center;
+  align-items: flex-end;
+  position: relative;
+}
+
+.dish-card:hover .restaurant-info {
+  background: $base-bkg-green;
+}
+.dish-card .restaurant-info:hover {
+  color: $accent-g;
+  font-weight: 500;
+}
+
+.dish-card .see-in-detail {
   padding: 7px;
   display: flex;
   justify-content: center;
@@ -118,9 +144,8 @@ a:hover {
   position: relative;
 }
 
-
-// .map-div {
-//   display: flex;
-//   width: 50vw;
-//   justify-content: center;
-// }
+.dish-card:hover .see-in-detail {
+  color: white;
+  font-weight: 500;
+  opacity: 1;
+}

--- a/app/assets/stylesheets/pages/_dishes_index.scss
+++ b/app/assets/stylesheets/pages/_dishes_index.scss
@@ -30,7 +30,7 @@
 // Container for dishes - grid
 .dishes-grid-cards {
   display: grid;
-  grid-template-columns: repeat(3, 300px);
+  grid-template-columns: repeat(2, 500px);
   grid-gap: 16px;
 }
 
@@ -55,9 +55,8 @@
 }
 
 .dish-card:hover {
-   background: $base-bkg-green;
+  background: $base-bkg-green;
 }
-
 
 .dish-card h2 {
   font-size: 16px;
@@ -71,6 +70,7 @@
   margin: 0;
 }
 
+// Disable links default style
 a {
   color: inherit;
 }
@@ -84,7 +84,7 @@ a:hover {
 .dish-card .dish-hero {
   background-size: cover;
   background-position: center;
-  height: 100px;
+  height: 150px;
   width: 100%;
   border-radius: 1px;
   box-shadow: 0 0 10px rgba(0,0,0,0.2);
@@ -94,7 +94,7 @@ a:hover {
   justify-content: space-around;
   font-size: 22px;
   color: white;
-  padding: 20px 10px;
+  padding: 30px 10px;
   letter-spacing: 1px;
   font-weight: 500;
   text-shadow: 0 0 10px rgba(0,0,0,0.7);

--- a/app/controllers/dishes_controller.rb
+++ b/app/controllers/dishes_controller.rb
@@ -3,7 +3,7 @@ class DishesController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[index show]
 
   def index
-    @dishes = [Dish.all.includes(:restaurant, :recipe), Dish.all.includes(:restaurant, :recipe)].flatten
+    @dishes = Dish.all.includes(:restaurant, :recipe)
 
     @markers = @dishes.map do |dish|
       {

--- a/app/views/dishes/_info_window.html.erb
+++ b/app/views/dishes/_info_window.html.erb
@@ -1,3 +1,4 @@
-<h5><%= dish.restaurant.name %></h5>
-<p><%= dish.restaurant.address %></p>
-<%= link_to "View in detail", dish_path(dish), class: "btn-pka" %>
+<%# <%= link_to(dish.restaurant) do %>
+  <h5><%= dish.restaurant.name %></h5>
+  <p><%= dish.restaurant.address %></p>
+<%# <%= link_to "View in detail", dish_path(dish), class: "btn-pka" %>

--- a/app/views/dishes/_info_window.html.erb
+++ b/app/views/dishes/_info_window.html.erb
@@ -1,4 +1,6 @@
-<%# <%= link_to(dish.restaurant) do %>
-  <h5><%= dish.restaurant.name %></h5>
-  <p><%= dish.restaurant.address %></p>
-<%# <%= link_to "View in detail", dish_path(dish), class: "btn-pka" %>
+<div>
+  <%= link_to(dish.restaurant) do %>
+    <h6><%= dish.restaurant.name %></h6>
+    <p><%= dish.restaurant.address %></p>
+  <% end %>
+</div>

--- a/app/views/dishes/index.html.erb
+++ b/app/views/dishes/index.html.erb
@@ -7,7 +7,7 @@
     <%@dishes.each do |dish| %>
       <div class="dish-card">
         <%= link_to(dish) do %>
-          <div class="dish-hero" style="background-image: url(http://kitt.lewagon.com/placeholder/cities/rio)">
+          <div class="dish-hero" style="background-image: linear-gradient(rgba(0,0,0,0.4), rgba(0,0,0,0.4)), url(https://ichef.bbci.co.uk/food/ic/food_16x9_1600/recipes/salad_verte_with_15684_16x9.jpg)">
             <%= simple_format(dish.recipe.name, {}, wrapper_tag: "div") %>
           </div>
           <div class="dish-infos">
@@ -17,9 +17,14 @@
             </div>
             <h2 class="dish-price"> £<%= dish.price %> </h2>
           </div>
-          <div class="restaurant-info">
-              <p><i class="fas fa-map-marker-alt"></i> <%= dish.restaurant.name %></p>
-          </div>
+            <%= link_to(dish.restaurant) do %>
+              <div class="restaurant-info">
+                  <p><i class="fas fa-map-marker-alt"></i> <%= dish.restaurant.name %></p>
+              </div>
+            <% end %>
+          <%# <div class="see-in-detail"> %>
+            <%# <p>See in detail</p> %>
+          <%# </div> %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/dishes/index.html.erb
+++ b/app/views/dishes/index.html.erb
@@ -8,7 +8,7 @@
       <div class="dish-card">
         <%= link_to(dish) do %>
           <div class="dish-hero" style="background-image: url(http://kitt.lewagon.com/placeholder/cities/rio)">
-            <%= simple_format(dish.recipe.name.capitalize, {}, wrapper_tag: "div") %>
+            <%= simple_format(dish.recipe.name, {}, wrapper_tag: "div") %>
           </div>
           <div class="dish-infos">
             <div>

--- a/app/views/dishes/index.html.erb
+++ b/app/views/dishes/index.html.erb
@@ -8,7 +8,7 @@
       <div class="dish-card">
         <%= link_to(dish) do %>
           <div class="dish-hero" style="background-image: url(http://kitt.lewagon.com/placeholder/cities/rio)">
-            <%= dish.recipe.name %>
+            <%= simple_format(dish.recipe.name.capitalize, {}, wrapper_tag: "div") %>
           </div>
           <div class="dish-infos">
             <div>

--- a/db/migrate/20211130022848_add_img_url_to_restaurant.rb
+++ b/db/migrate/20211130022848_add_img_url_to_restaurant.rb
@@ -1,0 +1,5 @@
+class AddImgUrlToRestaurant < ActiveRecord::Migration[6.0]
+  def change
+    add_column :restaurants, :img_url, :text
+  end
+end

--- a/db/recipe_seeds.rb
+++ b/db/recipe_seeds.rb
@@ -8,139 +8,139 @@ def build_recipes
   # dependent on test-user with user_id = 1 to exist!
 
   Recipe.create!(
-    name: "GNOCCHI Á LA TOMATE FRAÎCHE",
+    name: "Gnocchi á la Tomate Fraîche",
     method: "Gnocchi with Cherry Tomato Garlic and Parmesan",
     user_id: 1
   )
 
   Recipe.create!(
-    name: "PAPPARDELLE FRAICHES, SAUCE BOLOGNAISE DE VEAU",
+    name: "Pappardelle Fraiches,\nSauce Bolognaise de Veau",
     method: "Homemade Pappardelle, Veal Ragú",
     user_id: 1
   )
 
   Recipe.create!(
-    name: "PÂTES FRAÎCHES AUX CALAMARS, CREVETTES ET CHORIZO",
+    name: "Pâtes Fraîches aux Calamars,\nCrevettes et Chorizo",
     method: "Homemade Pasta with Squid, Prawns and Chorizo",
     user_id: 1
   )
 
   Recipe.create!(
-    name: "TURBOT AUX ARTICHAUTS BARIGOULE",
+    name: "Turbot aux Artichauts Barigoule",
     method: "Turbot with Artichokes, Chorizo, White Wine and Olive Oil",
     user_id: 1
   )
 
   Recipe.create!(
-    name: "GROSSES CREVETTES GRILLÉES",
+    name: "Grosses Crevettes Grillées",
     method: "Grilled Tiger Prawns",
     user_id: 1
   )
 
   Recipe.create!(
-    name: "LOUP DE MER EN CROÛTE DE SEL",
+    name: "Loup de Mer en Croûte de Sel",
     method: "Salt Baked Fillet of Line Caught Sea Bass with Artichokes and Tomatoes",
     user_id: 1
   )
 
   Recipe.create!(
-    name: "DAURADE AU CITRON",
+    name: "Daurade au Citron",
     method: "Whole Sea Bream Baked en Papillote with Lemon, Herbs and Olive Oil",
     user_id: 1
   )
 
   Recipe.create!(
-    name: "SÔLE POÊLÉE AU GRAIN DE MOUTARDE",
+    name: "Sôle Poêlée au Grain de Moutarde",
     method: "Pan Fried Dover Sole with a Grainy Mustard Dressing",
     user_id: 1
   )
 
   Recipe.create!(
-    name: "ENTRECÔTES GRILLÉE",
+    name: "Entrecôtes Grillée",
     method: "Grilled Rib Eye Steak 400gr",
     user_id: 1
   )
 
   Recipe.create!(
-    name: "CÔTES DE VEAU GRILLÉE",
+    name: "Côtes de Veau Grillée",
     method: "Grilled Veal Chop",
     user_id: 1
   )
 
   Recipe.create!(
-    name: "CÔTELETTES D'AGNEAU VIVIENNE",
+    name: "Côtelettes d'Agneau Vivienne",
     method: "Grilled Lamb Cutlets with Smoked Aubergine",
     user_id: 1
   )
 
   Recipe.create!(
-    name: "COQUELET AU CITRON CONFIT",
+    name: "Coquelet au Citron Confit",
     method: "Roast Baby Chicken Marinated in Lemon",
     user_id: 1
   )
 
   Recipe.create!(
-    name: "CANARD À L’ORANGE",
+    name: "Canard à l’Orange",
     method: "Slow Cooked Duck Legs with Orange Glaze",
     user_id: 1
   )
 
   Recipe.create!(
-    name: "POULET FAÇON “LPM”*",
-    method: "Whole Roast Black Leg Chicken *Please pre-order, subject to availability",
+    name: "Poulet Façon “LPM”",
+    method: "Whole Roast Black Leg Chicken",
     user_id: 1
   )
 
   Recipe.create!(
-    name: "CARRÉ D’ AGNEAU ENTIER*",
-    method: "Whole Roast Rack of Lamb with Spiced Couscous* Please pre-order, subject to availability",
+    name: "Carré d’Agneau Entier",
+    method: "Whole Roast Rack of Lamb with Spiced Couscous",
     user_id: 1
   )
 
   Recipe.create!(
-    name: "CÔTE DE BOEUF*",
-    method: "Rib of Beef, *Please pre-order, subject to availability",
+    name: "Côte de boeuf",
+    method: "Rib of Beef",
     user_id: 1
   )
 
   Recipe.create!(
-    name: "RATATOUILLE DE HAWAZEN",
+    name: "Ratatouille de Hawazen",
     method: "Hot Mediterranean Vegetables with Chickpeas",
     user_id: 1
   )
 
   Recipe.create!(
-    name: "BROCOLIS",
+    name: "Brocolis",
     method: "Sautéed Broccoli",
     user_id: 1
   )
 
   Recipe.create!(
-    name: "HARICOTS VERTS",
+    name: "Haricots Verts",
     method: "Green Beans",
     user_id: 1
   )
 
   Recipe.create!(
-    name: "POMMES DE TERRE GRATINÉES",
+    name: "Pommes de Terre Gratinées",
     method:"Baked Gratinated Potatoes",
     user_id: 1
   )
 
   Recipe.create!(
-    name: "FRITES",
+    name: "Frites",
     method: "French Fried Potatoes",
     user_id: 1
   )
 
   Recipe.create!(
-    name: "SALADE VERTE",
+    name: "Salade Verte",
     method: "Mixed Leaf Salad",
     user_id: 1
   )
 
   Recipe.create!(
-    name: "CAROTTE ROTIE",
+    name: "Carotte rotie",
     method: "Roasted Carrot, Caramelized Onion and Candied Walnut",
     user_id: 1
   )

--- a/db/restaurant_seeds.rb
+++ b/db/restaurant_seeds.rb
@@ -6,52 +6,51 @@ def build_restaurants
 
   puts "starting to create restaurants"
 
-  Restaurant.create(
-    name: "La Petit Maison London",
-    address: "53-54 Brook's Mews London, W1K 4EG",
-    description: "Chef Raphael Duntoye serves upscale French Mediterranean food to chic crowd in smart dining room. Our dress code is smart casual. No shorts or sportswear. Smart trainers are acceptable.",
-    deliveroo_link: "https://deliveroo.co.uk/menu/london/mayfair/lpm-restaurant-and-bar"
-  )
 
   Restaurant.create(
-    name: "Lucky Cat - Kori Kitchen Table",
-    address: "10 Grosvenor Square London, W1K 6JP",
-    description: "TThis Japanese inspired Chef's Table is designed to be booked exclusively for up to ten guests. Chefs will guide your group through each course, finishing dishes in front of you.",
-    opentable_link: "https://www.opentable.co.uk/r/lucky-cat-kori-kitchen-table-london"
+    name: "La Petit Maison London",
+    address: "53-54 Brook's Mews, London W1K 4EG",
+    description: "Chef Raphael Duntoye serves upscale French Mediterranean food to chic crowd in smart dining room. Our dress code is smart casual. No shorts or sportswear. Smart trainers are acceptable.",
+    deliveroo_link: "https://deliveroo.co.uk/menu/london/mayfair/lpm-restaurant-and-bar",
+    img_url: "https://www.telegraph.co.uk/content/dam/luxury/2020/10/02/011A2475-HDR-1_trans_NvBQzQNjv4BqWlxWmJPgkV9VyUT7QSPhw0JkFFn0JW618qGMadt37CU.jpg"
   )
 
   Restaurant.create(
     name: "Bocconcino",
-    address: "19 Berkeley Street London, W1J 8ED",
+    address: "19 Berkeley Street, London W1J 8ED",
     description: "Bocconcino is an Italian fine dining restaurant in London, nestled in the heart of Mayfair. Step away from the bustle of Berkeley Street and into a stunning space that will transport you and your guests to the gorgeous climes of Italy, featuring authentic Italian cuisine with a contemporary flair, first class service, expertly produced cocktails, and a rich selection of wines. The restaurant benefits from a lively ambiance with DJ nights and a weekend bottomless brunch.
 Their Chefs use only high quality ingredients imported straight from the diverse regions Italy, offering an excellent range of antipasti, hand-made pasta and wood-oven pizza. Larger dishes include an array of fresh seafood, catch of the day beautifully presented on their rich fish display.
 The first Bocconcino restaurant was opened in a beautiful seaside Forte dei Marmi, and Bocconcino has since expanded to London and has been offering delicious food and first-class service in a stylish location in Central London.",
     opentable_link: "https://www.opentable.co.uk/bocconcino",
-    deliveroo_link: "https://deliveroo.co.uk/menu/london/mayfair/bocconcino-mayfair"
+    deliveroo_link: "https://deliveroo.co.uk/menu/london/mayfair/bocconcino-mayfair",
+    img_url: "https://headbox-media.imgix.net/uploads/space_photo/filename/107294/Untitled_design.jpg?auto=compress,format"
   )
 
   Restaurant.create(
     name: "Bombay Bustle",
-    address: "29 Maddox Street London, W1S 2PA",
+    address: "29 Maddox Street, London W1S 2PA",
     description: "Bombay Bustle is inspired by the tiffin tin carriers, the institution of men who use Mumbai’s famed local railway to deliver home cooked meals across the city. The Maddox Street restaurant pays homage to the culture and people, whose expanse of origins from across India have influenced its culinary history.
 The menu sees recreations of some of the city’s most loved dishes alongside family recipes. Seasonal delights, inspired by Mumbai and the surrounding areas, include Bambaiya Ragda topped with dry peas and honey yogurt , Pickling spice Lamb chop , Prawn tawa Pulao along with Kerala home style Vegetable Istew with Appam and a Jalebi Cheesecake with Bombay Cutting Chai.",
     opentable_link: "https://www.opentable.co.uk/r/bombay-bustle-london",
-    deliveroo_link: "https://deliveroo.co.uk/menu/london/mayfair/smd-concepts-ltd"
+    deliveroo_link: "https://deliveroo.co.uk/menu/london/mayfair/smd-concepts-ltd",
+    img_url: "https://cdn.thenudge.com/wp-content/uploads/2017/03/bombay-bustle-restaurant-interior.jpg"
   )
 
   Restaurant.create(
     name: "Lucky Cat by Gordon Ramsay",
-    address: "10 Grosvenor Square London, W1K 6JP",
+    address: "10 Grosvenor Square, London W1K 6JP",
     description: "Located in London's Mayfair, Lucky Cat by Gordon Ramsay is an Asian open kitchen and late night lounge inspired by the drinking clubs of 1930s Tokyo and the Far East.
 Dine on Asian inspired small plates, Robata grilled dishes, sushi and sashimi that have been exquisitely crafted in the open kitchen and signature raw bar. Gordon and his Executive Head Chef, Ben Orpwood, have designed each dish to be shared at the centre of the table.",
-    opentable_link: "https://www.opentable.co.uk/r/lucky-cat-by-gordon-ramsay-london"
+    opentable_link: "https://www.opentable.co.uk/r/lucky-cat-by-gordon-ramsay-london",
+    img_url: "https://headbox-media.imgix.net/uploads/space_photo/filename/107294/Untitled_design.jpg?auto=compress,format"
   )
 
   Restaurant.create(
     name: "Galvin at Windows",
-    address: "London Hilton 22 Park Lane London, W1K 1BE",
+    address: "London Hilton 22 Park Lane, London W1K 1BE",
     description: "An irresistible offer to enrapture the palate and senses - welcome to Galvin at Windows, a multiple-award-winning London rooftop dining destination with breathtaking 360-degree panoramas. Savour the most gratifying highlights of seasonal gastronomy, expertly prepared by Head Chef Marc Hardiman and his trusted professional team. This exquisite London restaurant graces the highest point of London Hilton on Park Lane providing the most exquisite backdrop for fine dining and all special occasions.",
-    opentable_link: "https://www.opentable.co.uk/galvin-at-windows"
+    opentable_link: "https://www.opentable.co.uk/galvin-at-windows",
+    img_url: "https://headbox-media.imgix.net/uploads/space_photo/filename/68061/Whole_venue_1.jpg?auto=compress,format"
   )
 
   # https://res.cloudinary.com/p-ka/image/upload/v1638095731/development/pka_res_hardrockcafe.jpg
@@ -80,10 +79,11 @@ Dine on Asian inspired small plates, Robata grilled dishes, sushi and sashimi th
 
   Restaurant.create(
     name: "Hard Rock Cafe - London",
-    address: "150 Old Park Lane London, ENG W1K 1QZ",
+    address: "150 Old Park Lane, London W1K 1QZ",
     description: "Hard Rock Cafe is a global phenomenon with 185 cafes that are visited by nearly 80 million guests each year. The first Hard Rock Cafe opened on June 14, 1971, in London, England, and from there the brand has expanded to major cities and exotic locations around the world.",
     opentable_link: "https://www.opentable.co.uk/hard-rock-cafe-london",
-    ubereats_link: "https://www.ubereats.com/store/hard-rock-cafe/j2IWh1vrQ9uNJGGW7esong"
+    ubereats_link: "https://www.ubereats.com/store/hard-rock-cafe/j2IWh1vrQ9uNJGGW7esong",
+    img_url: "https://resizer.otstatic.com/v2/photos/wide-huge/1/25908286.jpg"
     # photo: open("https://res.cloudinary.com/p-ka/image/upload/v1638095731/development/pka_res_hardrockcafe.jpg")
     # photo: photo
   )
@@ -97,21 +97,23 @@ Dine on Asian inspired small plates, Robata grilled dishes, sushi and sashimi th
 
   Restaurant.create(
     name: "Afternoon Tea at The Chesterfield Mayfair",
-    address: "35 Charles Street London, W1J 5EB",
+    address: "35 Charles Street, London W1J 5EB",
     description: "Afternoon Tea is quite an event at The Chesterfield Mayfair - regularly commended at the Afternoon Tea Awards. A member of The Tea Guild, a prestigious and unique organisation that represents outlets dedicated to brewing and serving tea to the high standards desired by the United Kingdom Tea Council.
 Recognised for our outstanding quality and consistently high standards of tea service we pay suitable respect to its ritual while offering some exciting variations on the original. We take tremendous pleasure in serving a menu complete with homemade cakes, scones and pastries prepared by our chef pâtissier, in the heart of Mayfair.
 The Chesterfield Mayfair welcomes group enquiries for afternoon tea parties. With a number of private rooms available, The Chesterfield Mayfair makes an excellent location to celebrate birthdays, baby showers, hen parties, engagements and children's parties. Our events team would be happy to discuss your requirements.",
-    opentable_link: "https://www.opentable.co.uk/r/afternoon-tea-at-the-chesterfield-mayfair-london"
+    opentable_link: "https://www.opentable.co.uk/r/afternoon-tea-at-the-chesterfield-mayfair-london",
+    img_url: "https://resizer.otstatic.com/v2/photos/wide-huge/3/27790554.jpg"
   )
 
   Restaurant.create(
     name: "Hakkasan Mayfair",
-    address: "17 Bruton Street London, W1J 6QB",
+    address: "17 Bruton Street, London W1J 6QB",
     description: "This Michelin starred Chinese restaurant was designed by the famed Christian Liaigre, the intricate wooden lattice screens, carved out of dark English oak, invite discerning guests for a unique dining experience with contemporary cuisine. The menu has a strong Chinese ethnic identity with an ethos of Cantonese cooking.
 Hakkasan and Lucy Choi London are partnering in celebration of London Fashion Week 2019.
 Lucy Choi has created the Hakkasan Collection, three limited edition shoes inspired by Hakkasan, including the Mayfair, a red stiletto, and the Hanway Place, a black flat decorated with an embroidered tiger symbolising power, ferocity and beauty.
 To coincide with the launch, the Hakkasan Collection menu at Hakkasan Hanway Place and Hakkasan Mayfair showcases signature dishes alongside an exclusive dessert served in a glossy black shoebox as well as a cocktail, the Choi Ling. Priced at £90 per person, the menu is available until Sunday 17th November.",
-    opentable_link: "https://www.opentable.co.uk/hakkasan-mayfair"
+    opentable_link: "https://www.opentable.co.uk/hakkasan-mayfair",
+    img_url: "https://civilianglobal.com/wp-content/uploads/2017/11/img35032.1426x713.jpg"
   )
 
   Restaurant.create(
@@ -122,41 +124,46 @@ Enjoy the vibrant flavours of India with our Kenyan twist in our opulent Grade I
 Enriched with history, our recipes have been handed down 4 generations which not only adds to our authenticity but coupled with our must try signature dishes; makes us a firm favourite and the new talk of the town!
 Our cosy Lounge/Bar room is the ideal setting for those pre/post meal drinks. Between Thursday-Saturday (10pm onwards) the atmosphere heightens as our bar magicians become the life and soul of the bar.
 Please note: The restaurant does adhere to a dress code policy. Elegant/Smart casual (No sportswear or hats are permitted)",
-    opentable_link: "https://www.opentable.co.uk/r/madhus-at-the-dilly-london"
+    opentable_link: "https://www.opentable.co.uk/r/madhus-at-the-dilly-london",
+    img_url: "https://resizer.otstatic.com/v2/photos/wide-huge/2/46694289.jpg"
   )
 
   Restaurant.create(
     name: "Bond Street Kitchen",
-    address: "63 New Bond Street  London, W1S 1RQ",
+    address: "63 New Bond Street, London W1S 1RQ",
     description: "Synonymous with refined elegance and elevated service, Fenwick of Bond Street proudly presents Bond Street Kitchen.
 The perfect retreat from busy Mayfair, Bond Street Kitchen provides a relaxed and vibrant atmosphere, perfect for any occasion. Situated on the second floor of Fenwick, Bond Street Kitchen is ideal for shoppers needing a respite from their fashion travels, or business people looking for a stylish destination for a meeting. Guests can choose from a delicious menu of brunch, lunch and afternoon tea.
 Just as we at Fenwick of Bond Street carefully curate our edit, our chefs carefully source each ingredient to bring you a seasonal menu of modern British dishes, matched with a carefully chosen selection of wines. Offering a flavoursome, original and inspiring menu, Bond Street Kitchen provides beautifully executed cuisine in a casual dining setting.",
-    opentable_link: "https://www.opentable.co.uk/r/bond-street-kitchen-london"
+    opentable_link: "https://www.opentable.co.uk/r/bond-street-kitchen-london",
+    img_url: "https://i1.adis.ws/i/fenwick/19_09_12_Fenwick-04/Bond%20Street%20Kitchen"
   )
 
   Restaurant.create(
     name: "Rüya London",
-    address: "30 Upper Grosvenor Street London, W1K 7PH",
+    address: "30 Upper Grosvenor Street, London W1K 7PH",
     description: "This includes celery stalks, leaves, seeds and the root called celeriac. You can
   find celery in celery salt, salads, some meat products, soups and stock cubes.",
     opentable_link: "https://www.opentable.co.uk/r/ruya-london",
-    deliveroo_link: "https://deliveroo.co.uk/menu/london/mayfair/restaurant-craft-ltd"
+    deliveroo_link: "https://deliveroo.co.uk/menu/london/mayfair/restaurant-craft-ltd",
+    img_url: "https://cdn.thegentlemansjournal.com/wp-content/uploads/2018/08/header-10-2502x1200-c-center.jpg"
   )
 
   Restaurant.create(
     name: "Sexy Fish",
-    address: "Berkeley Square Berkeley Square House London, ENG  W1J 6BR",
+    address: "Berkeley Square Berkeley Square House, London ENG  W1J 6BR",
     description: "Sexy Fish is an Asian restaurant and bar located on the corner of Berkeley Square, Mayfair serving Japanese-inspired sushi, sashimi, seafood, fish and meat cooked on a Robata grill. The bar, which is open until late, holds the world’s biggest Japanese whisky collection, as well as offering a drinks menu featuring both classic and inventive cocktails.",
-    opentable_link: "https://www.opentable.co.uk/sexy-fish"
+    opentable_link: "https://www.opentable.co.uk/sexy-fish",
+    img_url: "https://viptableslondon.com/wp-content/uploads/2019/06/1470910157-sexy-fish-bar-min.jpg"
   )
 
   Restaurant.create(
     name: "El Norte",
-    address: "19 Dover St London, Greater London  W1S 4LU",
+    address: "19 Dover St, London W1S 4LU",
     description: "Bienvenidos a El Norte!
 Spanish Restaurant & Bar located in Dover street, the heart of Mayfair. Bringing the most popular dishes from Spain with a modern twist. Signature dishes include truffle tortilla, creamy croquettes, Joselito Iberico Ham, premium Vaca rubia Gallega steak... and many more! The wine menu has a selection of Spanish awarded labels carefully selected to accompany our dishes.
 A beautiful bar with irresistible Spanish crafted cocktails including a selection of home-made Sangrias with premium Spanish wine or champagne.",
-    opentable_link: "https://www.opentable.co.uk/r/el-norte-london"
+    opentable_link: "https://www.opentable.co.uk/r/el-norte-london",
+    img_url: "https://resizer.otstatic.com/v2/photos/wide-huge/3/43885344.jpg"
   )
 
   puts "created #{Restaurant.count} restaurants"

--- a/db/restaurant_seeds.rb
+++ b/db/restaurant_seeds.rb
@@ -78,7 +78,7 @@ Dine on Asian inspired small plates, Robata grilled dishes, sushi and sashimi th
   # signature = Cloudinary::Utils.api_sign_request({:public_id=>public_id, :version=>version}, "aiVZi1o_zRUe4U0d43GlpXhVcXE")
   # photo = "#{resource_type}/#{type}/v#{version}/#{public_id}.#{format}##{signature}"
 
-  hardrockcafe = Restaurant.create(
+  Restaurant.create(
     name: "Hard Rock Cafe - London",
     address: "150 Old Park Lane London, ENG W1K 1QZ",
     description: "Hard Rock Cafe is a global phenomenon with 185 cafes that are visited by nearly 80 million guests each year. The first Hard Rock Cafe opened on June 14, 1971, in London, England, and from there the brand has expanded to major cities and exotic locations around the world.",
@@ -87,11 +87,12 @@ Dine on Asian inspired small plates, Robata grilled dishes, sushi and sashimi th
     # photo: open("https://res.cloudinary.com/p-ka/image/upload/v1638095731/development/pka_res_hardrockcafe.jpg")
     # photo: photo
   )
-  # hardrockcafe_img = URI.open("https://res.cloudinary.com/p-ka/image/upload/w_1600,h_1600,c_crop,g_face,r_max/w_400/v1638101476/res_hardrockcafe.jpg")
+  # hardrockcafe_img = URI.open("https://res.cloudinary.com/p-ka/image/upload/v1638101476/res_hardrockcafe.jpg")
   # url_dev = "https://res.cloudinary.com/p-ka/image/upload/v1638200900/development/x2a8zemx8pjvp1d7nu9g388tr1zz.jpg"
   # url_devv = "https://res.cloudinary.com/p-ka/image/upload/v1638201289/development/ohp1lbdnu3dubxygvhx74jui5mgx.jpg"
   # url_r = "https://res.cloudinary.com/p-ka/image/upload/w_1600,h_1600,c_crop,g_face,r_max/w_400/v1638101476/res_hardrockcafe.jpg"
-  # hardrockcafe.photo.attach(filename: 'res_hardrockcafe.jpg', content_type: 'image/jpg', io: hardrockcafe_img)
+  # hardrockcafe.photo.attach(io: hardrockcafe_img, filename: 'res_hardrockcafe.jpg', content_type: 'image/jpg')
+  # hardrockcafe.save
   # p "#{hardrockcafe.photo.attached?}"
 
   Restaurant.create(

--- a/db/restaurant_seeds.rb
+++ b/db/restaurant_seeds.rb
@@ -6,6 +6,25 @@ def build_restaurants
 
   puts "starting to create restaurants"
 
+  Restaurant.create(
+    name: "Plants by Deliciously Ella",
+    address: "18 Weighhouse St, London W1K 5AH",
+    description: "Plants by DE highlights the delicious diversity and abundance of plants.
+You’ll find anything from pan-fried oyster mushroom scallops with carrot jelly; to asparagus ceviche; cauliflower schnitzel; grilled cabbage with lentil chimichurri; and the ultimate vegan pancakes with dark chocolate sauce.
+We make everything in house, including our cultured vegan butter, cashew crème fresh, and crushed walnut parmesan.",
+    opentable_link: "https://www.opentable.co.uk/r/plants-by-deliciously-ella-london",
+    img_url: "https://www.countryandtownhouse.co.uk/wp-content/uploads/2021/09/PLANTS_DELICIOUSLY-ELLA1117-min-1070x714.jpg"
+  )
+
+  Restaurant.create(
+    name: "Jamavar",
+    address: "8 Mount St, London W1K 3NF",
+    description: "With a seating capacity of 107 covers split in two different floors, a private dining room that accommodate up to 8 guests plus al fresco tables will provide the perfect setting for a thoroughly enjoyable experience.
+Taking inspiration from the Viceroy’s house of New Delhi, the restaurant will be a glamorous Indian dining room with rainforest emperador marbles, dark timber paneling, gilded walls, and Lutyens inspired furnishings. The space will reflect the vibrant colours and intricate patterns of rare Jamavar shawls, offset with brass accents, hand-cut marquetry, and a sculpted bar that will celebrate the great textile traditions of India.",
+    opentable_link: "https://www.opentable.co.uk/r/jamavar-london",
+    deliveroo_link:"https://deliveroo.co.uk/menu/london/mayfair/s-fiori-ltd",
+    img_url: "https://resizer.otstatic.com/v2/photos/wide-huge/1/24940452.jpg"
+  )
 
   Restaurant.create(
     name: "La Petit Maison London",

--- a/db/restaurant_seeds.rb
+++ b/db/restaurant_seeds.rb
@@ -47,16 +47,7 @@ Dine on Asian inspired small plates, Robata grilled dishes, sushi and sashimi th
     opentable_link: "https://www.opentable.co.uk/galvin-at-windows"
   )
 
-  # resource_type = "image"
-  # type = "upload"
-  # version = 1638101476
-  # folder = "pka-restaurant"
-  # public_id = "res_hardrockcafe"
-  # format = "jpg"
-  # signature = Cloudinary::Utils.api_sign_request({:public_id=>public_id,
-  # :version=>version}, Cloudinary.config.api_secret)
-  # photo = "#{resource_type}/#{type}/v#{version}/#{public_id}.#{format}##{signature}"
-
+  # https://res.cloudinary.com/p-ka/image/upload/v1638095731/development/pka_res_hardrockcafe.jpg
   # def full_identifier(image)
   #   params = {version: image.file.version, public_id: image.file.public_id}
   #   signature = Cloudinary::Utils.sign_request(params)[:signature]
@@ -70,16 +61,30 @@ Dine on Asian inspired small plates, Robata grilled dishes, sushi and sashimi th
   # new_folio = Folio.new(title: 'Test', body: 'Test One', position: 1, main_image: main_image, thumb_image: thumb_image)
   # new_folio.save
 
+  # https://res.cloudinary.com/p-ka/image/upload/v1638101476/res_hardrockcafe.jpg
+
+  # resource_type = "image"
+  # type = "upload"
+  # version = 1637066716
+  # public_id = "ikyieksnkomnwcl5gbym"
+  # format = "jpg"
+  # signature = Cloudinary::Utils.api_sign_request({:public_id=>public_id, :version=>version}, "aiVZi1o_zRUe4U0d43GlpXhVcXE")
+  # photo = "#{resource_type}/#{type}/v#{version}/#{public_id}.#{format}##{signature}"
+
   hardrockcafe = Restaurant.create(
     name: "Hard Rock Cafe - London",
     address: "150 Old Park Lane London, ENG W1K 1QZ",
     description: "Hard Rock Cafe is a global phenomenon with 185 cafes that are visited by nearly 80 million guests each year. The first Hard Rock Cafe opened on June 14, 1971, in London, England, and from there the brand has expanded to major cities and exotic locations around the world.",
     opentable_link: "https://www.opentable.co.uk/hard-rock-cafe-london",
-    ubereats_link: "https://www.ubereats.com/store/hard-rock-cafe/j2IWh1vrQ9uNJGGW7esong",
+    ubereats_link: "https://www.ubereats.com/store/hard-rock-cafe/j2IWh1vrQ9uNJGGW7esong"
+    # photo: open("https://res.cloudinary.com/p-ka/image/upload/v1638095731/development/pka_res_hardrockcafe.jpg")
     # photo: photo
   )
-  # hardrockcafe_img = URI.open('https://resizer.otstatic.com/v2/photos/wide-huge/1/25908286.jpg')
-  # hardrockcafe.photo.attach(io: hardrockcafe_img, filename: 'hardrockcafe.png', content_type: 'image/png')
+  # hardrockcafe_img = URI.open("https://res.cloudinary.com/p-ka/image/upload/w_1600,h_1600,c_crop,g_face,r_max/w_400/v1638101476/res_hardrockcafe.jpg")
+  # url_dev = "https://res.cloudinary.com/p-ka/image/upload/v1638200900/development/x2a8zemx8pjvp1d7nu9g388tr1zz.jpg"
+  # url_devv = "https://res.cloudinary.com/p-ka/image/upload/v1638201289/development/ohp1lbdnu3dubxygvhx74jui5mgx.jpg"
+  # url_r = "https://res.cloudinary.com/p-ka/image/upload/w_1600,h_1600,c_crop,g_face,r_max/w_400/v1638101476/res_hardrockcafe.jpg"
+  # hardrockcafe.photo.attach(filename: 'res_hardrockcafe.jpg', content_type: 'image/jpg', io: hardrockcafe_img)
   # p "#{hardrockcafe.photo.attached?}"
 
   Restaurant.create(

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_28_100936) do
+ActiveRecord::Schema.define(version: 2021_11_30_022848) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -102,6 +102,7 @@ ActiveRecord::Schema.define(version: 2021_11_28_100936) do
     t.float "latitude"
     t.float "longitude"
     t.text "ubereats_link"
+    t.text "img_url"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
- Add images to restaurants 
migration -> restaurant seed addition of link to image & uniformisation of the address
- Fix names of recipes capitalization (+ remove extra "*" info) from seeds
- Style (further) the dishes index page:
  - pop-ups - new look and link to the restaurant on click
  - restaurant link on restaurant info from dish cards
  - dish cards: image and recipe title display

Resolve #99 Resolve #125 Resolve #126 Resolve #127
You can find out more about what this branch implements by looking into the details of the issues linked to this PR.